### PR TITLE
Bump omero_prometheus_tools_version 0.1.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,4 +30,4 @@ omero_prometheus_exporter_counts_query_files:
 ######################################################################
 
 # Prometheus component versions
-omero_prometheus_tools_version: 0.1.0
+omero_prometheus_tools_version: 0.1.1


### PR DESCRIPTION
Update following https://github.com/ome/omero-prometheus-tools/pull/4

Tag: `0.1.1`