### PR TITLE
Renaming2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 OMERO Prometheus Exporter
 =========================
 
+[![Build Status](https://travis-ci.org/openmicroscopy/ansible-role-omero-prometheus-exporter.svg)](https://travis-ci.org/openmicroscopy/ansible-role-omero-prometheus-exporter)
+[![Ansible Role](https://img.shields.io/ansible/role/37759.svg)](https://galaxy.ansible.com/openmicroscopy/omero_prometheus_exporter/)
+
 OMERO Prometheus exporter.
 
 Configures services for exporting prometheus-compatible metrics from OMERO.server.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 galaxy_info:
-  role_name: omero_prometheus_tools
+  role_name: omero_prometheus_exporter
   author: ome-devel@lists.openmicroscopy.org.uk
   description: OMERO Prometheus exporter
   company: Open Microscopy Environment


### PR DESCRIPTION
Follow up of #3, @joshmoore rightfully noticed that the name of the role had changed (`exporter` -> `tools`).

This was an oversight and this should make the changes so that the role can be consumable from Galaxy as `openmicroscopy.omero_prometheus_exporter` in a requirements file.